### PR TITLE
Sha Upgrade

### DIFF
--- a/laurine.rb
+++ b/laurine.rb
@@ -1,7 +1,7 @@
 class Laurine < Formula
   homepage "https://github.com/JiriTrecak/Laurine/"
   url "https://github.com/JiriTrecak/Laurine/archive/0.2.2.tar.gz"
-  sha1 "1a80770ee4a52ca830b97e934aa6a06aa6cf435b"
+  sha256 "909a5a495fb21fa7e20b823b6415f4b33b609dba341ea603d68dffe331f92946"
   version "0.2.2"
 
   def install


### PR DESCRIPTION
- Upgraded deprecated sha1 to sha256.

Fixes the issue discussed here: https://github.com/JiriTrecak/Laurine/issues/37

Thanks to @jormungand for the fix.

Sha256 was generated using this method: http://stackoverflow.com/questions/32673943/how-to-update-homebrew-sha256